### PR TITLE
開催中のコンテストで404になる問題の修正

### DIFF
--- a/src/ac_scraper.rs
+++ b/src/ac_scraper.rs
@@ -460,9 +460,16 @@ pub async fn ac_submit(
     Ok(())
 }
 
-pub async fn get_sample_cases(problem_str_info: &ProblemStrInfo) -> reqwest::Result<Samples> {
+pub async fn get_sample_cases(
+    problem_str_info: &ProblemStrInfo,
+    acn: &ACN,
+) -> reqwest::Result<Samples> {
     let contest_url = str_format(CONTEST_URL.to_string(), problem_str_info);
-    let body = reqwest::get(contest_url)
+    let body = acn
+        .client
+        .get(contest_url)
+        .headers(acn.cookies.clone().unwrap_or(HeaderMap::new()))
+        .send()
         .await?
         .error_for_status()?
         .text()

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<()> {
         execute_with_manual_input(&problem_str_info, &acn.config_str_map)?;
         return Ok(());
     }
-    let samples = get_sample_cases(&problem_str_info).await?;
+    let samples = get_sample_cases(&problem_str_info, &acn).await?;
     let sample_results = sample_check(
         &problem_str_info,
         &samples,


### PR DESCRIPTION
close #16
get_sample_casesでcookieを使えていなかったので、修正。
ARC158で動作確認済み。